### PR TITLE
Add warnings as errors for tests

### DIFF
--- a/lib/medic/test.ex
+++ b/lib/medic/test.ex
@@ -11,6 +11,6 @@ defmodule Medic.Test do
   """
   def run do
     Medic.Cmd.run!("Compiling", "mix", ["compile", "--force", "--warnings-as-errors"], env: [{"MIX_ENV", "test"}])
-    Medic.Cmd.run!("Running tests", "mix", ["test", "--color"])
+    Medic.Cmd.run!("Running tests", "mix", ["test", "--color", "--warnings-as-errors"])
   end
 end


### PR DESCRIPTION
This is obviously a breaking change so wanted to create a PR so you can decide if it should be included or not. 

This is a new flag added in [Elixir 1.12](https://hexdocs.pm/mix/1.12.2/Mix.Tasks.Test.html). It works the same as the `mix compile` option, but for test `.exs` files. 

I've tested it on `jand`, `apex` and `herd` and they still pass with this flag